### PR TITLE
changes in the teammgrd to support single process and config updates …

### DIFF
--- a/cfgmgr/shellcmd.h
+++ b/cfgmgr/shellcmd.h
@@ -11,7 +11,6 @@
 #define BASH_CMD             "/bin/bash"
 #define GREP_CMD             "/bin/grep"
 #define TEAMD_CMD            "/usr/bin/teamd"
-#define TEAMD_CMD            "/usr/bin/teamd-multi"
 #define TEAMDCTL_CMD         "/usr/bin/teamdctl"
 #define IPTABLES_CMD         "/sbin/iptables"
 #define CONNTRACK_CMD        "/usr/sbin/conntrack"

--- a/cfgmgr/shellcmd.h
+++ b/cfgmgr/shellcmd.h
@@ -11,6 +11,7 @@
 #define BASH_CMD             "/bin/bash"
 #define GREP_CMD             "/bin/grep"
 #define TEAMD_CMD            "/usr/bin/teamd"
+#define TEAMD_CMD            "/usr/bin/teamd-multi"
 #define TEAMDCTL_CMD         "/usr/bin/teamdctl"
 #define IPTABLES_CMD         "/sbin/iptables"
 #define CONNTRACK_CMD        "/usr/sbin/conntrack"

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -102,7 +102,6 @@ TeamMgr::TeamMgr(DBConnector *confDb, DBConnector *applDb, DBConnector *statDb,
        SWSS_LOG_INFO("start single process with teamd...");
     }
 
-
 }
 
 bool TeamMgr::isPortStateOk(const string &alias)

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -20,12 +20,10 @@
 #include <sys/types.h>
 #include <signal.h>
 
-
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
 #include <cstring>
-
 
 using namespace std;
 using namespace swss;
@@ -735,7 +733,6 @@ int TeamMgr::sendIpcToTeamd(const std::string& command, const std::vector<std::s
     return task_success;
 }
 
-
 task_process_status TeamMgr::addLag(const string &alias, int min_links, bool fallback, bool fast_rate)
 {
     SWSS_LOG_ENTER();
@@ -814,21 +811,19 @@ task_process_status TeamMgr::addLag(const string &alias, int min_links, bool fal
     }
 
     else { 
+       cmd << TEAMD_CMD
+           << warmstart_flag
+           << " -t " << alias
+           << " -c " << conf.str()
+           << " -L " << dump_path
+           << " -g -d";
 
-
-    cmd << TEAMD_CMD
-        << warmstart_flag
-        << " -t " << alias
-        << " -c " << conf.str()
-        << " -L " << dump_path
-        << " -g -d";
-
-    if (exec(cmd.str(), res) != 0)
-    {
-        SWSS_LOG_INFO("Failed to start port channel %s with teamd, retry...",
-                alias.c_str());
-        return task_need_retry;
-    }
+       if (exec(cmd.str(), res) != 0)
+       {
+           SWSS_LOG_INFO("Failed to start port channel %s with teamd, retry...",
+                   alias.c_str());
+           return task_need_retry;
+       }
     }
 
     SWSS_LOG_NOTICE("Start port channel %s with teamd", alias.c_str());

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -747,7 +747,7 @@ task_process_status TeamMgr::addLag(const string &alias, int min_links, bool fal
     MacAddress mac_boot = m_mac;
 
     // set portchannel mac same with mac before warmStart, when warmStart and there
-    // is a file written by teamd.    
+    // is a file written by teamd.
     ifstream aliasfile(dump_path + alias);
     if (WarmStart::isWarmStart() && aliasfile.is_open())
     {
@@ -1071,7 +1071,6 @@ bool TeamMgr::removeLagMember(const string &lag, const string &member)
     if (m_teamdUnifiedProcMode) {
 	    sendIpcToTeamd("PortRemove", { lag, member });
     }
- 
     else {
 	    // teamdctl <port_channel_name> port remove <member>;
 	    cmd << TEAMDCTL_CMD << " " << lag << " port remove " << member << "; ";

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -19,7 +19,7 @@ public:
 
     using Orch::doTask;
     void ipcInitTeamd();
-    int send_ipc_to_teamd(const std::string& command,
+    int sendIpcToTeamd(const std::string& command,
                       const std::vector<std::string>& args);
     void cleanTeamProcesses();
     void ipcCleanup();
@@ -38,7 +38,7 @@ private:
     ProducerStateTable m_appLagTable;
 
     std::set<std::string> m_lagList;
-    bool m_teamdMode = false;
+    bool m_teamdUnifiedProcMode = false;
     int sockfd;
 
     MacAddress m_mac;

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -71,5 +71,4 @@ private:
 #define TEAMD_MULTI_SOCK_PATH "/var/run/teamd/teamd-unified.sock"
 #define TEAMD_IPC_REQ "REQUEST"
 
-
 }

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -25,6 +25,7 @@ private:
     Table m_cfgPortTable;
     Table m_cfgLagTable;
     Table m_cfgLagMemberTable;
+    Table m_cfgModeTable;
     Table m_statePortTable;
     Table m_stateLagTable;
     Table m_stateMACsecIngressSATable;
@@ -33,6 +34,7 @@ private:
     ProducerStateTable m_appLagTable;
 
     std::set<std::string> m_lagList;
+     std::string m_teamdMode;
 
     MacAddress m_mac;
 
@@ -40,6 +42,7 @@ private:
     void doLagTask(Consumer &consumer);
     void doLagMemberTask(Consumer &consumer);
     void doPortUpdateTask(Consumer &consumer);
+    void doTeamdmodeTask(Consumer &consumer);
 
     task_process_status addLag(const std::string &alias, int min_links, bool fall_back, bool fast_rate);
     bool removeLag(const std::string &alias);
@@ -61,4 +64,6 @@ private:
     uint16_t generateLacpKey(const std::string&);
 };
 
+#define TEAMD_MULTI_SOCK_PATH "/var/run/teamd/teamd.sock"
+#define TEAMD_IPC_REQ "REQUEST"
 }

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -18,7 +18,11 @@ public:
             const std::vector<TableConnector> &tables);
 
     using Orch::doTask;
+    void ipcInitTeamd();
+    int send_ipc_to_teamd(const std::string& command,
+                      const std::vector<std::string>& args);
     void cleanTeamProcesses();
+    void ipcCleanup();
 
 private:
     Table m_cfgMetadataTable;   // To retrieve MAC address
@@ -34,7 +38,8 @@ private:
     ProducerStateTable m_appLagTable;
 
     std::set<std::string> m_lagList;
-     std::string m_teamdMode;
+    bool m_teamdMode = false;
+    int sockfd;
 
     MacAddress m_mac;
 
@@ -64,6 +69,8 @@ private:
     uint16_t generateLacpKey(const std::string&);
 };
 
-#define TEAMD_MULTI_SOCK_PATH "/var/run/teamd/teamd.sock"
+#define TEAMD_MULTI_SOCK_PATH "/var/run/teamd/teamd-unified.sock"
 #define TEAMD_IPC_REQ "REQUEST"
+
+
 }

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -47,7 +47,6 @@ private:
     void doLagTask(Consumer &consumer);
     void doLagMemberTask(Consumer &consumer);
     void doPortUpdateTask(Consumer &consumer);
-    void doTeamdmodeTask(Consumer &consumer);
 
     task_process_status addLag(const std::string &alias, int min_links, bool fall_back, bool fast_rate);
     bool removeLag(const std::string &alias);

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -54,11 +54,13 @@ int main(int argc, char **argv)
 
         TableConnector conf_lag_table(&conf_db, CFG_LAG_TABLE_NAME);
         TableConnector conf_lag_member_table(&conf_db, CFG_LAG_MEMBER_TABLE_NAME);
+	TableConnector conf_teamd_mode_table(&conf_db, CFG_TEAMD_MODE_TABLE_NAME);
         TableConnector state_port_table(&state_db, STATE_PORT_TABLE_NAME);
 
         vector<TableConnector> tables = {
             conf_lag_table,
             conf_lag_member_table,
+	    conf_teamd_mode_table,
             state_port_table
         };
 

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -66,6 +66,7 @@ int main(int argc, char **argv)
 
         TeamMgr teammgr(&conf_db, &app_db, &state_db, tables);
 
+	teammgr.ipcInitTeamd();
         vector<Orch *> cfgOrchList = {&teammgr};
 
         Select s;
@@ -95,6 +96,7 @@ int main(int argc, char **argv)
             c->execute();
         }
         teammgr.cleanTeamProcesses();
+	teammgr.ipcCleanup(); 
         SWSS_LOG_NOTICE("Exiting");
     }
     catch (const exception &e)

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -66,7 +66,6 @@ int main(int argc, char **argv)
 
         TeamMgr teammgr(&conf_db, &app_db, &state_db, tables);
 
-	teammgr.ipcInitTeamd();
         vector<Orch *> cfgOrchList = {&teammgr};
 
         Select s;

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -53,6 +53,7 @@ public:
         static const struct team_change_handler gPortChangeHandler;
     private:
         ProducerStateTable *m_lagMemberTable;
+	struct team_netlink *m_nl;
         struct team_handle *m_team;
         std::string m_lagName;
         int m_ifindex;

--- a/tests/mock_tests/teammgrd/teamd_ipc.h
+++ b/tests/mock_tests/teammgrd/teamd_ipc.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <vector>
+#include <string>
+#include "orch.h"
+
+// Weak declaration
+__attribute__((weak)) int send_ipc_to_teamd(const std::string &method, const std::vector<std::string> &args);

--- a/tests/mock_tests/teammgrd/teammgr_ut.cpp
+++ b/tests/mock_tests/teammgrd/teammgr_ut.cpp
@@ -164,8 +164,6 @@ namespace teammgr_ut
 	    swss::Table cfg_mode_table = swss::Table(m_config_db.get(), CFG_TEAMD_MODE_TABLE_NAME);
             cfg_mode_table.set("GLOBAL",{ {"mode","multi-process"} });
 
-
-
             TableConnector conf_lag_table(m_config_db.get(), CFG_LAG_TABLE_NAME);
             TableConnector conf_lag_member_table(m_config_db.get(), CFG_LAG_MEMBER_TABLE_NAME);
             TableConnector state_port_table(m_state_db.get(), STATE_PORT_TABLE_NAME);

--- a/tests/mock_tests/teammgrd/teammgr_ut.cpp
+++ b/tests/mock_tests/teammgrd/teammgr_ut.cpp
@@ -1,7 +1,17 @@
 #include "gtest/gtest.h"
+#include <gmock/gmock.h>
 #include "../mock_table.h"
 #include "teammgr.h"
 #include <dlfcn.h>
+#include "teamd_ipc.h"
+
+using ::testing::_;
+using ::testing::Return;
+
+using namespace testing;  // <-- Needed to use EXPECT_CALL, DoAll, Return, etc.
+using namespace boost::mpl::placeholders;  // Optional, if using Boost placeholders
+
+std::function<int(const std::string &, const std::vector<std::string> &)> g_mock_send_ipc_to_teamd;
 
 extern int (*callback)(const std::string &cmd, std::string &stdout);
 extern std::vector<std::string> mockCallArgs;
@@ -10,6 +20,11 @@ static std::map<std::string, std::FILE*> pidFiles;
 
 static int (*callback_kill)(pid_t pid, int sig) = NULL;
 static std::pair<bool, FILE*> (*callback_fopen)(const char *pathname, const char *mode) = NULL;
+
+int send_ipc_to_teamd(const std::string &method, const std::vector<std::string> &args)
+{
+    return g_mock_send_ipc_to_teamd(method, args);
+}
 
 static int cb_kill(pid_t pid, int sig)
 {
@@ -146,6 +161,10 @@ namespace teammgr_ut
             std::vector<swss::FieldValueTuple> vec;
             vec.emplace_back("mac", "01:23:45:67:89:ab");
             metadata_table.set("localhost", vec);
+	    swss::Table cfg_mode_table = swss::Table(m_config_db.get(), CFG_TEAMD_MODE_TABLE_NAME);
+            cfg_mode_table.set("GLOBAL",{ {"mode","multi-process"} });
+
+
 
             TableConnector conf_lag_table(m_config_db.get(), CFG_LAG_TABLE_NAME);
             TableConnector conf_lag_member_table(m_config_db.get(), CFG_LAG_MEMBER_TABLE_NAME);
@@ -185,6 +204,7 @@ namespace teammgr_ut
         teammgr.addExistingData(&cfg_lag_table);
         teammgr.doTask();
         ASSERT_NE(mockCallArgs.size(), 0);
+	ASSERT_FALSE(mockCallArgs.empty());
         EXPECT_NE(mockCallArgs.front().find("/usr/bin/teamd -r -t PortChannel382"), std::string::npos);
         EXPECT_EQ(mockCallArgs.size(), 1);
         EXPECT_EQ(mockKillCommands.size(), 1);
@@ -263,5 +283,30 @@ namespace teammgr_ut
         std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
         EXPECT_EQ(mockKillCommands.size(), 0);
         EXPECT_GE(std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count(), 200);
+    }
+
+    TEST_F(TeamMgrTest, testIpcSendRetry)
+    {
+        swss::Table cfg_mode_table(m_config_db.get(), CFG_TEAMD_MODE_TABLE_NAME);
+        swss::Table cfg_lag_table(m_config_db.get(), CFG_LAG_TABLE_NAME);
+	cfg_mode_table.del("GLOBAL");
+        cfg_lag_table.set("PortChannel123", {
+            {"admin_status", "up"},
+            {"mtu", "9100"},
+            {"lacp_key", "auto"},
+            {"min_links", "1"}
+        });
+
+        g_mock_send_ipc_to_teamd = [](const std::string &method, const std::vector<std::string> &args) -> int {
+            if (method == "PortChannelAdd" && !args.empty() && args[0]== "PortChannel123")
+            {
+                return task_need_retry;
+            }
+            return task_success;
+        };
+
+        swss::TeamMgr teammgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_lag_tables);
+        teammgr.addExistingData(&cfg_lag_table);
+        teammgr.doTask();
     }
 }

--- a/tlm_teamd/main.cpp
+++ b/tlm_teamd/main.cpp
@@ -138,7 +138,6 @@ int main()
             }
             else if (res == swss::Select::TIMEOUT)
             {
-
                 teamdctl_mgr.process_add_queue();
                 // In the case of lag removal, there is a scenario where the select::TIMEOUT
                 // occurs, it triggers get_dumps incorrectly for resource which was in process of 

--- a/tlm_teamd/main.cpp
+++ b/tlm_teamd/main.cpp
@@ -10,7 +10,6 @@
 #include "teamdctl_mgr.h"
 #include "values_store.h"
 #include "subintf.h"
-#include <syslog.h>
 
 
 bool g_run = true;
@@ -102,9 +101,8 @@ int main()
         swss::Table table(&config_db, "TEAMD");
         std::vector<swss::FieldValueTuple> values;
 
-        std::string m_teamdmode;
+        std::string m_teamdMultiProcMode = "unified";
         bool  key_exists = table.get("GLOBAL", values);
-        syslog(LOG_INFO,"mode exists :%d",key_exists);
 
         if (key_exists && !values.empty())
         {
@@ -113,16 +111,15 @@ int main()
                 if (fv.first == "mode" && fv.second == "multi-process")
 
                 {
-                    syslog(LOG_INFO,"switching to legacy mode %s:%s",fv.first.c_str(),fv.second.c_str());
-                    m_teamdmode = fv.second;
+                    m_teamdMultiProcMode = fv.second;
                     break;
                 }
             }
 	}
-    	if (m_teamdmode == "multi-process") {
-		teamdctl_mgr.m_Mode = false;
+    	if (m_teamdMultiProcMode == "multi-process") {
+		teamdctl_mgr.m_teamdUnifiedProcMode = false;
     	} else {
-		teamdctl_mgr.m_Mode = true;
+		teamdctl_mgr.m_teamdUnifiedProcMode = true;
 	}
 
 

--- a/tlm_teamd/teamdctl_mgr.cpp
+++ b/tlm_teamd/teamdctl_mgr.cpp
@@ -66,9 +66,7 @@ bool TeamdCtlMgr::has_key(const std::string & lag_name) const
 /// @return true if the lag was added or postponed successfully, false otherwise
 ///
 bool TeamdCtlMgr::add_lag(const std::string & lag_name)
-
 {
-
     if (has_key(lag_name))
     {
         SWSS_LOG_DEBUG("The LAG '%s' was already added. Skip adding it.", lag_name.c_str());
@@ -142,16 +140,14 @@ bool TeamdCtlMgr::remove_lag(const std::string & lag_name)
 	if (m_teamdUnifiedProcMode) 
         {
 		m_handlers.erase(lag_name);
-		SWSS_LOG_NOTICE("The LAG '%s' has been removed from db.", lag_name.c_str());
-
 	}
 	else {
 		auto tdc = m_handlers[lag_name];
 	   	teamdctl_disconnect(tdc);
 		teamdctl_free(tdc);
 		m_handlers.erase(lag_name);
-	 	SWSS_LOG_NOTICE("The LAG '%s' has been removed.", lag_name.c_str());
 	}
+        SWSS_LOG_NOTICE("The LAG '%s' has been removed from db.", lag_name.c_str());
     }
     else if (m_lags_to_add.find(lag_name) != m_lags_to_add.end())
     {
@@ -371,7 +367,7 @@ int TeamdCtlMgr::sendIpcToTeamd(const std::string& command,
         return -1;
     }
 
-    char buffer[16384];
+    char buffer[65536];
     ssize_t received = recv(sockfd, buffer, sizeof(buffer) - 1, 0);
     if (received > 0)
     {

--- a/tlm_teamd/teamdctl_mgr.cpp
+++ b/tlm_teamd/teamdctl_mgr.cpp
@@ -134,7 +134,6 @@ bool TeamdCtlMgr::try_add_lag(const std::string & lag_name)
 bool TeamdCtlMgr::remove_lag(const std::string & lag_name)
 {
 
-
     if (has_key(lag_name))
     {
 	if (m_teamdUnifiedProcMode) 

--- a/tlm_teamd/teamdctl_mgr.h
+++ b/tlm_teamd/teamdctl_mgr.h
@@ -6,7 +6,6 @@
 
 #include <teamdctl.h>
 
-
 using TeamdCtlDump = std::pair<bool, std::string>;
 using TeamdCtlDumpsEntry = std::pair<std::string, std::string>;
 using TeamdCtlDumps = std::vector<TeamdCtlDumpsEntry>;

--- a/tlm_teamd/teamdctl_mgr.h
+++ b/tlm_teamd/teamdctl_mgr.h
@@ -6,6 +6,7 @@
 
 #include <teamdctl.h>
 
+
 using TeamdCtlDump = std::pair<bool, std::string>;
 using TeamdCtlDumpsEntry = std::pair<std::string, std::string>;
 using TeamdCtlDumps = std::vector<TeamdCtlDumpsEntry>;
@@ -21,6 +22,11 @@ public:
     // Retry logic added to prevent incorrect error reporting in dump API's
     TeamdCtlDump get_dump(const std::string & lag_name, bool to_retry);
     TeamdCtlDumps get_dumps(bool to_retry);
+    int send_ipc_to_teamd(const std::string& command,
+                      const std::vector<std::string>& args,
+                      std::string& response_out);
+    bool m_Mode = false;
+
 
 private:
     bool has_key(const std::string & lag_name) const;
@@ -29,6 +35,11 @@ private:
     std::unordered_map<std::string, struct teamdctl*> m_handlers;
     std::unordered_map<std::string, int> m_lags_to_add;
     std::unordered_map<std::string, int> m_lags_err_retry;
+    int sockfd;
 
     const int max_attempts_to_add = 10;
 };
+
+
+#define TEAMD_MULTI_SOCK_PATH "/var/run/teamd/teamd-unified.sock"
+#define TEAMD_IPC_REQ "REQUEST"

--- a/tlm_teamd/teamdctl_mgr.h
+++ b/tlm_teamd/teamdctl_mgr.h
@@ -22,10 +22,10 @@ public:
     // Retry logic added to prevent incorrect error reporting in dump API's
     TeamdCtlDump get_dump(const std::string & lag_name, bool to_retry);
     TeamdCtlDumps get_dumps(bool to_retry);
-    int send_ipc_to_teamd(const std::string& command,
+    int sendIpcToTeamd(const std::string& command,
                       const std::vector<std::string>& args,
                       std::string& response_out);
-    bool m_Mode = false;
+    bool m_teamdUnifiedProcMode = false;
 
 
 private:


### PR DESCRIPTION
Mode-Based Process Initialization via Redis:-
1.Subscribe and listen to mode configuration in Redis to decide and initialize either single or multiple teamd processes accordingly.
2.Send PortChannel create/del requests via IPC based on mode configuration
3.send Port member add/del requests from teammgrd via ipc with portchannel name 

please find the attached test logs.
[teammgrd_log.txt](https://github.com/user-attachments/files/19964218/teammgrd_log.txt)

Please find the logs for mock test.
![test_coverage](https://github.com/user-attachments/assets/97c1538b-07a0-4498-9327-dfe025e402b4)


